### PR TITLE
Using readable-stream instead of native srteam module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {Readable} = require('stream');
+const {Readable} = require('readable-stream');
 
 module.exports = input => (
 	new Readable({

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
 		"ava": "*",
 		"get-stream": "^3.0.0",
 		"xo": "*"
+	},
+	"dependencies": {
+		"readable-stream": "^2.3.6"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import {Readable} from 'stream';
+import {Readable} from 'readable-stream';
 import test from 'ava';
 import getStream from 'get-stream';
 import toReadableStream from '.';


### PR DESCRIPTION
Using readable-stream instead of stream to allow universal behavior across Node modules. **readable-stream** is an up-to-date and multi-version compatible representation of the core streams' module and ensures consistency.