### PR TITLE
Use readable-stream instead of stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {Readable} = require('stream');
+const {Readable} = require('readable-stream');
 
 module.exports = input => (
 	new Readable({

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
 		"ava": "*",
 		"get-stream": "^3.0.0",
 		"xo": "*"
+	},
+	"dependencies": {
+		"readable-stream": "^3.0.3"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import {Readable} from 'stream';
+import {Readable} from 'readable-stream';
 import test from 'ava';
 import getStream from 'get-stream';
 import toReadableStream from '.';


### PR DESCRIPTION
According to [this](https://github.com/nodejs/readable-stream), it is better to use `readable-stream`.

As stated:

> If you want to guarantee a stable streams base, regardless of what version of Node you, or the users of your libraries are using, use readable-stream only and avoid the "stream" module in Node-core,

EDIT: Checking out your profile, you probably already know this though. Sorry if I sounded like a jerk 😄 